### PR TITLE
fix: removed spaces in status

### DIFF
--- a/lua/doing/view.lua
+++ b/lua/doing/view.lua
@@ -43,15 +43,15 @@ function View.render()
     return "ERR: " .. left
   end
 
-  return ' ' .. left .. '  ' .. right .. ' '
+  if not right then
+    return left
+  end
+
+  return left .. '  ' .. right
 end
 
 function View.render_inactive()
-  if not View.is_visible() then
-    return ""
-  end
-
-  return "  "
+  return ""
 end
 
 View.stl = "%!v:lua.DoStatusline('active')"


### PR DESCRIPTION
Left & right spaces are not needed.
For example, the lualine has padding property for spacing. Also, other plugins usually don't add start/end spaces to improve appearance