### PR TITLE
!tweak(ignored_buffers): now checks against filename/filetype and accepts functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 A tiny task manager within nvim that helps you stay on track by keeping a stack
 of tasks and always showing which task is at the top and how many more you have.
 
+It works by storing the tasks in a plain text file
+
 this plugin was originally a fork of [nocksock/do.nvim](https://github.com/nocksock/do.nvim)
 
 ![doing](https://raw.githubusercontent.com/Hashino/doing.nvim/main/demo.gif)
@@ -36,21 +38,20 @@ return {
   config = function()
     require('doing').setup {
       message_timeout = 2000,
+      doing_prefix = 'Doing: ',
 
       -- doesn't display on buffers that match filetype/filename to entries
       -- can be either an array or a function that returns an array
       ignored_buffers = { 'NvimTree' }
 
-      winbar = { 
-        enabled = true,
-      },
-
-      doing_prefix = 'Current Task: ',
+        -- if plugin should manage the winbar
+      winbar = { enabled = true, },
 
       store = {
+        -- name of tasks file
+        file_name = '.tasks',
         -- automatically create a task file when openning directories
         auto_create_file = false, 
-        file_name = '.tasks',
       },
     }
     -- example on how to change the winbar highlight

--- a/README.md
+++ b/README.md
@@ -1,22 +1,11 @@
 # Doing.nvim
 
-A tiny task manager within nvim that helps you stay on track.
+A tiny task manager within nvim that helps you stay on track by keeping a stack
+of tasks and always showing which task is at the top and how many more you have.
 
 this plugin was originally a fork of [nocksock/do.nvim](https://github.com/nocksock/do.nvim)
 
 ![doing](https://raw.githubusercontent.com/Hashino/doing.nvim/main/demo.gif)
-
-## Rationale
-
-While coding, we often need to do several things that depend on another.
-And it's quite easy to loose track of what we initially set out to do in the first place, which is also know as [Yak Shaving](https://en.wiktionary.org/wiki/yak_shaving).
-_Or_ we just have a list of tasks that we want to work off step by step.
-
-This plugin provides a few simple commands to help you stay on track.
-
-It manages a list of things and always shows you the first item.
-It provides you with some commands to add things to it, without leaving context.
-And it uses a simple, intuitive floating buffer to manage that list.
 
 ## Usage
 
@@ -46,18 +35,21 @@ return {
   'hashino/doing.nvim',
   config = function()
     require('doing').setup {
-      -- default options
       message_timeout = 2000,
+
+      -- doesn't display on buffers that match filetype/filename to entries
+      -- can be either an array or a function that returns an array
+      ignored_buffers = { 'NvimTree' }
+
       winbar = { 
         enabled = true,
-        -- ignores buffers that match filetype
-        ignored_buffers = { 'NvimTree' }
       },
 
       doing_prefix = 'Current Task: ',
+
       store = {
-        -- automatically create a .tasks when calling :Do
-        auto_create_file = true, 
+        -- automatically create a task file when openning directories
+        auto_create_file = false, 
         file_name = '.tasks',
       },
     }

--- a/lua/doing/core.lua
+++ b/lua/doing/core.lua
@@ -6,6 +6,7 @@ local state = require("doing.state")
 local utils = require("doing.utils")
 
 ---Setup doing.nvim
+---@param opts Options
 function Core.setup(opts)
   state.options = vim.tbl_deep_extend("force", state.default_opts, opts or {})
   state.tasks = state.init(state.options.store)

--- a/lua/doing/state.lua
+++ b/lua/doing/state.lua
@@ -1,10 +1,15 @@
 local State = {}
 
+---@class Options
+---@field ignored_buffers string[]|fun():string[] elements of the array are checked against buffer filename/filetype
+---@field message_timeout integer how many millisecons messages will stay on screen
+---@field doing_prefix string prefix to show before the task
+---@field winbar.enabled boolean if plugin should manage the winbar
+---@field store.file_name string name of the task file
+---@field store.auto_create_file boolean if true, creates task file on opening directory
 State.default_opts = {
   message_timeout = 2000,
   doing_prefix = "Doing: ",
-
-
   ignored_buffers = { "NvimTree" },
 
   winbar = {
@@ -12,8 +17,8 @@ State.default_opts = {
   },
 
   store = {
+    file_name = ".tasks",
     auto_create_file = false,
-    file_name = ".tasks"
   }
 }
 
@@ -25,7 +30,6 @@ State.options = State.default_opts
 
 ---initialize task store
 State.init = function(options)
-
   local default_state = {
     options = options,
     file = nil,

--- a/lua/doing/state.lua
+++ b/lua/doing/state.lua
@@ -4,9 +4,11 @@ State.default_opts = {
   message_timeout = 2000,
   doing_prefix = "Doing: ",
 
+
+  ignored_buffers = { "NvimTree" },
+
   winbar = {
     enabled = true,
-    ignored_buffers = { "NvimTree" },
   },
 
   store = {

--- a/lua/doing/utils.lua
+++ b/lua/doing/utils.lua
@@ -17,7 +17,7 @@ function Utils.should_display_task()
     return false
   end
 
-  local ignore = state.options.winbar.ignored_buffers
+  local ignore = state.options.ignored_buffers
 
   if type(ignore) == "function" then
     ignore = ignore()

--- a/lua/doing/utils.lua
+++ b/lua/doing/utils.lua
@@ -17,13 +17,21 @@ function Utils.should_display_task()
     return false
   end
 
-  for _, exclude in ipairs(state.options.winbar.ignored_buffers) do
-    if string.find(vim.bo.filetype, exclude) then
+  local ignore = state.options.winbar.ignored_buffers
+
+  if type(ignore) == "function" then
+    ignore = ignore()
+  end
+
+  for _, exclude in ipairs(ignore) do
+    if string.find(vim.bo.filetype, exclude) or
+        vim.fn.expand("%") == exclude
+    then
       return false
     end
   end
 
-  return vim.fn.win_gettype() == ""
+  return vim.fn.win_gettype() == "" -- normal window
       and vim.bo.buftype ~= "prompt"
 end
 


### PR DESCRIPTION
ignored_buffers is now outside the scope of winbar (check README.MD) and can also be a function that returns an array of strings.

added type annotations for ease of configuration 

fixes #8