### PR TITLE
Applied fix to quitting ':Do edit' 

### DIFF
--- a/lua/doing.lua
+++ b/lua/doing.lua
@@ -138,6 +138,7 @@ function Doing.edit()
 
     vim.keymap.set("n", "q", function()
       Doing.editor.win = vim.api.nvim_win_close(Doing.editor.win, true)
+      Doing.editor.win = nil
     end, { buffer = Doing.editor.buf, })
   end
 end


### PR DESCRIPTION
Applied a fix by setting Doing.editor.win to `nil` when quitting it so that it does not retain its previous value and prevent the window from being displayed more than once.